### PR TITLE
Make cloudflare/wasm optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,10 @@ jobs:
       run: |
         # Only check compilation for WASM, don't run tests
         # WASM binaries cannot be executed on GitHub runners
-        cargo check --target wasm32-unknown-unknown
+        cargo check --target wasm32-unknown-unknown --no-default-features --features "cloudflare"
         
     - name: Build WASM release
-      run: cargo build --target wasm32-unknown-unknown --release
+      run: cargo build --target wasm32-unknown-unknown --no-default-features --features "cloudflare" --release
 
   publish-dry-run:
     name: Test Package Structure

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Rust
-/target/
+target/
 **/*.rs.bk
 Cargo.lock
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ readme = "README.md"
 keywords = ["orm", "libsql", "database", "sqlite", "wasm"]
 categories = ["database", "web-programming", "wasm", "asynchronous"]
 exclude = [
-    "target/",
-    ".git/",
-    ".gitignore",
-    "tests/",
-    "BOOLEAN_CONVERSION_FIX.md",
+  "target/",
+  ".git/",
+  ".gitignore",
+  "tests/",
+  "BOOLEAN_CONVERSION_FIX.md",
 ]
 
 [package.metadata.docs.rs]
@@ -24,7 +24,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-libsql = { version = "0.9.14", default-features = false, features = ["cloudflare"] }
+libsql = { version = "0.9.14", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
@@ -32,22 +32,22 @@ uuid = { version = "1.0", features = ["v4", "serde", "js"] }
 libsql-orm-macros = { version = "0.1.1", path = "./libsql-orm-macros" }
 anyhow = "1.0"
 worker = { version = "0.6", optional = true }
+web-sys = { version = "0.3", features = ["console"], optional = true }
 log = "0.4"
-web-sys = { version = "0.3", features = ["console"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"] }
 env_logger = "0.10"
 
 [features]
-default = []
-cloudflare = ["worker"]
+default = ["libsql_default"]
+cloudflare = ["worker", "web-sys", "libsql/cloudflare"]
+libsql_default = ["libsql/default"]
 
 [lib]
 name = "libsql_orm"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
-
 
 
 [workspace]


### PR DESCRIPTION
This changes the default features of libsql_orm to libsql/default but can be overridden to use cloudflare with a feature. Note that due to feature specification using cloudflare requires the use of default-features=false when using this crate (after this PR merges)