### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ayonsaha2011/libsql-orm/security/code-scanning/14](https://github.com/ayonsaha2011/libsql-orm/security/code-scanning/14)

The best fix is to add a `permissions: contents: read` block at the root of the workflow file, just below the `name:` and before `on:`. This sets read-only permissions for the GITHUB_TOKEN for all jobs in this workflow, following the principle of least privilege. None of the jobs shown require any write access (e.g. to issues or pull-requests), so this is sufficient. No further changes are necessary to the steps or jobs themselves, and no new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
